### PR TITLE
Add fullscreen mode via a cli flag

### DIFF
--- a/border.go
+++ b/border.go
@@ -14,18 +14,19 @@ type Border struct {
 func NewBorder(width, height int) *Border {
 	b := new(Border)
 	b.Entity = tl.NewEntity(1, 1, 1, 1)
-	b.width, b.height = width, height
+	// Subtract one to account for bottom and right border
+	b.width, b.height = width-1, height-1
 
 	b.coords = make(map[Coord]int)
 
 	// Top and bottom
-	for x := 0; x < width; x++ {
+	for x := 0; x < b.width; x++ {
 		b.coords[Coord{x, 0}] = 1
 		b.coords[Coord{x, b.height}] = 1
 	}
 
 	// Left and right
-	for y := 0; y < height+1; y++ {
+	for y := 0; y < b.height+1; y++ {
 		b.coords[Coord{0, y}] = 1
 		b.coords[Coord{b.width, y}] = 1
 	}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"math/rand"
 	"time"
 
 	tl "github.com/JoelOtter/termloop"
+	"github.com/nsf/termbox-go"
 )
 
 var score = 0
@@ -30,6 +32,9 @@ func EndGame() {
 }
 
 func main() {
+	isFullscreen := flag.Bool("fullscreen", false, "Play fullscreen!")
+	flag.Parse()
+
 	rand.Seed(time.Now().UnixNano())
 	game = tl.NewGame()
 
@@ -37,7 +42,13 @@ func main() {
 		Bg: tl.ColorBlack,
 	})
 
-	border = NewBorder(80, 30)
+	width, height := 80, 30
+	if *isFullscreen {
+		// Must initialize Termbox before getting the terminal size
+		termbox.Init()
+		width, height = termbox.Size()
+	}
+	border = NewBorder(width, height)
 
 	snake := NewSnake()
 	food := NewFood()


### PR DESCRIPTION
First pass at a way to play snake-go full terminal. Use the new `-fulllscreen` flag to test it out!

Fixes #4 